### PR TITLE
fix: passing down formOptions to vue-form-generator

### DIFF
--- a/src/components/field-object.vue
+++ b/src/components/field-object.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="schema.schema">
-      <vue-form-generator :schema="schema.schema" :model="value"></vue-form-generator>
+      <vue-form-generator :schema="schema.schema" :model="value" :options="formOptions"></vue-form-generator>
     </div>
     <div v-else>
       <table :id="getFieldID(schema)" :class="schema.fieldClasses">


### PR DESCRIPTION
vfg-field-object component not passing the user specified "formOptions" to "vue-form-generator" options.
So by default "vue-form-generator" sets "validateAfterLoad" & "validateAfterChanged" to false which makes the form fields not validating the input change.

I have added the code to pass formOptions props to "options" props in "vue-form-generator" component.

Please accept this PR and reflect changes in real package.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No